### PR TITLE
battery/performance optimizations for earth rendering

### DIFF
--- a/src/shadow.c
+++ b/src/shadow.c
@@ -35,6 +35,11 @@ static void draw_earth() {
   // Earth's inclination is 23.4 degrees, so sun should vary 23.4/90=.26 up and down
   int sun_y = -sin_lookup((day_of_year - 0.2164) * TRIG_MAX_ANGLE) * .26 * .25;
   // ##### draw the bitmap
+  uint8_t *world_data = gbitmap_get_data(world_bitmap);
+#ifdef PBL_BW
+  uint8_t *image_data = gbitmap_get_data(image);
+#endif
+  int row_bytes = gbitmap_get_bytes_per_row(world_bitmap);
   int x, y;
   for(x = 0; x < width; x++) {
     int x_angle = (int)((float)TRIG_MAX_ANGLE * (float)x / (float)(width));
@@ -44,20 +49,20 @@ static void draw_earth() {
       float angle = ((float)sin_lookup(sun_y)/(float)TRIG_MAX_RATIO) * ((float)sin_lookup(y_angle)/(float)TRIG_MAX_RATIO);
       angle = angle + ((float)cos_lookup(sun_y)/(float)TRIG_MAX_RATIO) * ((float)cos_lookup(y_angle)/(float)TRIG_MAX_RATIO) * ((float)cos_lookup(sun_x - x_angle)/(float)TRIG_MAX_RATIO);
 #ifdef PBL_BW
-      int byte = y * gbitmap_get_bytes_per_row(world_bitmap) + (int)(x / 8);
-      if ((angle < 0) ^ (0x1 & (((char *)gbitmap_get_data(world_bitmap))[byte] >> (7 - x % 8)))) {
+      int byte = y * row_bytes + (int)(x / 8);
+      if ((angle < 0) ^ (0x1 & (world_data[byte] >> (7 - x % 8)))) {
         // white pixel
-        ((char *)gbitmap_get_data(image))[byte] = ((char *)gbitmap_get_data(image))[byte] | (0x1 << (7 - x % 8));
+        image_data[byte] = image_data[byte] | (0x1 << (7 - x % 8));
       } else {
         // black pixel
-        ((char *)gbitmap_get_data(image))[byte] = ((char *)gbitmap_get_data(image))[byte] & ~(0x1 << (7 - x % 8));
+        image_data[byte] = image_data[byte] & ~(0x1 << (7 - x % 8));
       }
 #else
-      int byte = y * gbitmap_get_bytes_per_row(world_bitmap) + x;
+      int byte = y * row_bytes + x;
       if (angle < 0) { // dark pixel
-        gbitmap_get_data(world_bitmap)[byte] = gbitmap_get_data(world_bitmap)[width*height + byte];
+        world_data[byte] = world_data[width*height + byte];
       } else { // light pixel
-        gbitmap_get_data(world_bitmap)[byte] = gbitmap_get_data(world_bitmap)[width*height*2 + byte];
+        world_data[byte] = world_data[width*height*2 + byte];
       }
 #endif
     }

--- a/src/shadow.c
+++ b/src/shadow.c
@@ -48,9 +48,9 @@ static void draw_earth() {
 #endif
   int x, y;
   for(x = 0; x < width; x++) {
-    int x_angle = (int)((float)TRIG_MAX_ANGLE * (float)x / (float)(width));
+    int x_angle = TRIG_MAX_ANGLE * x / width;
     for(y = 0; y < height; y++) {
-      int y_angle = (int)((float)TRIG_MAX_ANGLE * (float)y / (float)(height * 2)) - TRIG_MAX_ANGLE/4;
+      int y_angle = TRIG_MAX_ANGLE * y / (height * 2) - TRIG_MAX_ANGLE/4;
       // spherical law of cosines
       float angle = sin_sun * ((float)sin_lookup(y_angle)/(float)TRIG_MAX_RATIO);
       angle = angle + cos_sun * ((float)cos_lookup(y_angle)/(float)TRIG_MAX_RATIO) * ((float)cos_lookup(sun_x - x_angle)/(float)TRIG_MAX_RATIO);

--- a/src/shadow.c
+++ b/src/shadow.c
@@ -47,15 +47,18 @@ static void draw_earth() {
   uint8_t *day_data = night_data + row_bytes * height;
 #endif
   int x, y;
-  for(x = 0; x < width; x++) {
-    int x_angle = TRIG_MAX_ANGLE * x / width;
-    for(y = 0; y < height; y++) {
-      int y_angle = TRIG_MAX_ANGLE * y / (height * 2) - TRIG_MAX_ANGLE/4;
+  for(y = 0; y < height; y++) {
+    int row_offset = y * row_bytes;
+    int y_angle = TRIG_MAX_ANGLE * y / (height * 2) - TRIG_MAX_ANGLE/4;
+    float sin_y = (float)sin_lookup(y_angle) / (float)TRIG_MAX_RATIO;
+    float cos_y = (float)cos_lookup(y_angle) / (float)TRIG_MAX_RATIO;
+    for(x = 0; x < width; x++) {
+      int x_angle = TRIG_MAX_ANGLE * x / width;
       // spherical law of cosines
-      float angle = sin_sun * ((float)sin_lookup(y_angle)/(float)TRIG_MAX_RATIO);
-      angle = angle + cos_sun * ((float)cos_lookup(y_angle)/(float)TRIG_MAX_RATIO) * ((float)cos_lookup(sun_x - x_angle)/(float)TRIG_MAX_RATIO);
+      float angle = sin_sun * sin_y;
+      angle = angle + cos_sun * cos_y * ((float)cos_lookup(sun_x - x_angle)/(float)TRIG_MAX_RATIO);
 #ifdef PBL_BW
-      int byte = y * row_bytes + (int)(x / 8);
+      int byte = row_offset + (int)(x / 8);
       if ((angle < 0) ^ (0x1 & (world_data[byte] >> (7 - x % 8)))) {
         // white pixel
         image_data[byte] = image_data[byte] | (0x1 << (7 - x % 8));
@@ -64,7 +67,7 @@ static void draw_earth() {
         image_data[byte] = image_data[byte] & ~(0x1 << (7 - x % 8));
       }
 #else
-      int byte = y * row_bytes + x;
+      int byte = row_offset + x;
       if (angle < 0) { // dark pixel
         world_data[byte] = night_data[byte];
       } else { // light pixel

--- a/src/shadow.c
+++ b/src/shadow.c
@@ -72,9 +72,13 @@ static void draw_watch(struct Layer *layer, GContext *ctx) {
 static void handle_minute_tick(struct tm *tick_time, TimeUnits units_changed) {
   static char time_text[6]; // "00:00\0"
   static char date_text[12]; // "Xxx, Xxx 00\0"
+  static int last_date_yday = -1;
 
-  strftime(date_text, sizeof(date_text), "%a, %b %e", tick_time);
-  text_layer_set_text(date_text_layer, date_text);
+  if (tick_time->tm_yday != last_date_yday) {
+    last_date_yday = tick_time->tm_yday;
+    strftime(date_text, sizeof(date_text), "%a, %b %e", tick_time);
+    text_layer_set_text(date_text_layer, date_text);
+  }
 
   if (clock_is_24h_style()) {
     strftime(time_text, sizeof(time_text), "%R", tick_time);

--- a/src/shadow.c
+++ b/src/shadow.c
@@ -40,6 +40,10 @@ static void draw_earth() {
   uint8_t *image_data = gbitmap_get_data(image);
 #endif
   int row_bytes = gbitmap_get_bytes_per_row(world_bitmap);
+#ifndef PBL_BW
+  uint8_t *night_data = world_data + row_bytes * height;
+  uint8_t *day_data = night_data + row_bytes * height;
+#endif
   int x, y;
   for(x = 0; x < width; x++) {
     int x_angle = (int)((float)TRIG_MAX_ANGLE * (float)x / (float)(width));
@@ -60,9 +64,9 @@ static void draw_earth() {
 #else
       int byte = y * row_bytes + x;
       if (angle < 0) { // dark pixel
-        world_data[byte] = world_data[width*height + byte];
+        world_data[byte] = night_data[byte];
       } else { // light pixel
-        world_data[byte] = world_data[width*height*2 + byte];
+        world_data[byte] = day_data[byte];
       }
 #endif
     }

--- a/src/shadow.c
+++ b/src/shadow.c
@@ -34,6 +34,8 @@ static void draw_earth() {
   // 0.2164 is march 20, the 79th day of the year, the march equinox
   // Earth's inclination is 23.4 degrees, so sun should vary 23.4/90=.26 up and down
   int sun_y = -sin_lookup((day_of_year - 0.2164) * TRIG_MAX_ANGLE) * .26 * .25;
+  float sin_sun = (float)sin_lookup(sun_y) / (float)TRIG_MAX_RATIO;
+  float cos_sun = (float)cos_lookup(sun_y) / (float)TRIG_MAX_RATIO;
   // ##### draw the bitmap
   uint8_t *world_data = gbitmap_get_data(world_bitmap);
 #ifdef PBL_BW
@@ -50,8 +52,8 @@ static void draw_earth() {
     for(y = 0; y < height; y++) {
       int y_angle = (int)((float)TRIG_MAX_ANGLE * (float)y / (float)(height * 2)) - TRIG_MAX_ANGLE/4;
       // spherical law of cosines
-      float angle = ((float)sin_lookup(sun_y)/(float)TRIG_MAX_RATIO) * ((float)sin_lookup(y_angle)/(float)TRIG_MAX_RATIO);
-      angle = angle + ((float)cos_lookup(sun_y)/(float)TRIG_MAX_RATIO) * ((float)cos_lookup(y_angle)/(float)TRIG_MAX_RATIO) * ((float)cos_lookup(sun_x - x_angle)/(float)TRIG_MAX_RATIO);
+      float angle = sin_sun * ((float)sin_lookup(y_angle)/(float)TRIG_MAX_RATIO);
+      angle = angle + cos_sun * ((float)cos_lookup(y_angle)/(float)TRIG_MAX_RATIO) * ((float)cos_lookup(sun_x - x_angle)/(float)TRIG_MAX_RATIO);
 #ifdef PBL_BW
       int byte = y * row_bytes + (int)(x / 8);
       if ((angle < 0) ^ (0x1 & (world_data[byte] >> (7 - x % 8)))) {

--- a/src/shadow.c
+++ b/src/shadow.c
@@ -123,7 +123,7 @@ static void window_load(Window *window) {
   text_layer_set_text_alignment(date_text_layer, GTextAlignmentCenter);
   layer_add_child(window_layer, text_layer_get_layer(date_text_layer));
 
-  canvas = layer_create(GRect(0, 0, bounds.size.w, bounds.size.h));
+  canvas = layer_create(GRect(0, 0, width, height));
   layer_set_update_proc(canvas, draw_watch);
   layer_add_child(window_layer, canvas);
 #ifdef PBL_BW


### PR DESCRIPTION
Description

This PR applies a series of small, atomic optimizations to the watchface. The changes focus on reducing unnecessary layer updates, avoiding repeated bitmap access work inside the render loop, and improving earth bitmap drawing locality.

## Changes

- Limit the earth canvas layer to the bitmap bounds instead of the full window.
- Update the date text only when the local day changes, rather than every minute.
- Cache bitmap data pointers and row stride once per earth redraw.
- Cache color bitmap day/night plane pointers.
- Cache sun sine/cosine values once per earth redraw.
- Use integer math for simple pixel-to-angle conversions.
- Draw the earth row-by-row for better memory locality.
- Compute latitude trig values once per row instead of once per pixel.

## Testing

Built successfully using `pebble build`.
Side loaded onto my pebble time 2.
Will push further commits if I see any bugs introduced.